### PR TITLE
Implemeted Multitasking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,9 @@ $(BUILD_DIR)/mouse.o: $(SRC_DIR)/drivers/mouse.cpp
 $(BUILD_DIR)/vga.o: $(SRC_DIR)/drivers/vga.cpp 
 	$(CC) $(CFLAGS) -c $< -o $@
 
+$(BUILD_DIR)/multitasking.o: $(SRC_DIR)/multitasking/multitasking.cpp 
+	$(CC) $(CFLAGS) -c $< -o $@
+
 $(BUILD_DIR)/driver.o: $(SRC_DIR)/drivers/driver.cpp 
 	$(CC) $(CFLAGS) -c $< -o $@
 
@@ -67,7 +70,7 @@ $(BUILD_DIR)/kernel.bin: $(BUILD_DIR)/kernel.o $(BUILD_DIR)/multiboot.o         
 	                     $(BUILD_DIR)/gdt.o $(BUILD_DIR)/stdio.o                     \
 						 $(BUILD_DIR)/interrupts.o $(BUILD_DIR)/interruptstub.o $(BUILD_DIR)/port.o \
 						 $(BUILD_DIR)/driver.o   $(BUILD_DIR)/pci.o \
-						 $(BUILD_DIR)/keyboard.o $(BUILD_DIR)/mouse.o  $(BUILD_DIR)/vga.o
+						 $(BUILD_DIR)/keyboard.o $(BUILD_DIR)/mouse.o  $(BUILD_DIR)/vga.o $(BUILD_DIR)/multitasking.o
 
 	$(LD) $(LDFLAGS) -o $@ $^
 

--- a/src/core/interrupts/interrupts.cpp
+++ b/src/core/interrupts/interrupts.cpp
@@ -56,10 +56,13 @@ namespace uqaabOS
 
     // setup interrupt manager
     InterruptManager::InterruptManager(uint16_t hardware_interrupt_offset,
-                                       uqaabOS::include::GDT *gdt)
+                                       uqaabOS::include::GDT *gdt , multitasking::TaskManager* task_manager)
         : PIC_master_command_port(0x20), PIC_master_data_port(0x21),
           PIC_slave_command_port(0xA0), PIC_slave_data_port(0xA1)
     {
+
+      this -> task_manager = task_manager;
+
       this->hardware_interrupt_offset = hardware_interrupt_offset;
       // ISR code segment
       uint32_t code_segment = gdt->code_segment_selector();
@@ -247,6 +250,10 @@ uint32_t InterruptManager::do_handle_interrupt(uint8_t interrupt_number,
     } else {
       libc::printf("UNHANDLED INTERRUPT 0x%02X\n", interrupt_number);
     }
+  }
+
+  if(interrupt_number == hardware_interrupt_offset){
+    esp = (uint32_t)task_manager -> schedule((multitasking::CPUState*)esp);
   }
 
       if (hardware_interrupt_offset <= interrupt_number &&

--- a/src/core/interrupts/interrupts.cpp
+++ b/src/core/interrupts/interrupts.cpp
@@ -253,7 +253,7 @@ uint32_t InterruptManager::do_handle_interrupt(uint8_t interrupt_number,
   }
 
   if(interrupt_number == hardware_interrupt_offset){
-    esp = (uint32_t)task_manager -> schedule((multitasking::CPUState*)esp);
+    esp = (uint32_t)(task_manager -> schedule((multitasking::CPUState*)esp));
   }
 
       if (hardware_interrupt_offset <= interrupt_number &&

--- a/src/core/interrupts/interrupts.cpp
+++ b/src/core/interrupts/interrupts.cpp
@@ -1,220 +1,208 @@
 #include "../../include/interrupts.h"
 #include "../../include/libc/stdio.h"
 
-namespace uqaabOS
-{
-  namespace interrupts
-  {
+namespace uqaabOS {
+namespace interrupts {
 
-    InterruptManager *InterruptManager::ActiveInterrruptManager = 0;
+InterruptManager *InterruptManager::ActiveInterrruptManager = 0;
 
-    InterruptHandler::InterruptHandler(InterruptManager *interrupt_manager,
-                                       uint8_t interrupt_number)
-    {
-      this->interrupt_manager = interrupt_manager;
-      this->interrupt_number = interrupt_number;
-      interrupt_manager->handlers[interrupt_number] = this;
-    }
+InterruptHandler::InterruptHandler(InterruptManager *interrupt_manager,
+                                   uint8_t interrupt_number) {
+  this->interrupt_manager = interrupt_manager;
+  this->interrupt_number = interrupt_number;
+  interrupt_manager->handlers[interrupt_number] = this;
+}
 
-    InterruptHandler::~InterruptHandler()
-    {
-      if (interrupt_manager->handlers[interrupt_number] != 0)
-      {
-        interrupt_manager->handlers[interrupt_number] = 0;
-      }
-    }
+InterruptHandler::~InterruptHandler() {
+  if (interrupt_manager->handlers[interrupt_number] != 0) {
+    interrupt_manager->handlers[interrupt_number] = 0;
+  }
+}
 
-    uint32_t InterruptHandler::handle_interrupt(uint32_t esp) { return esp; }
+uint32_t InterruptHandler::handle_interrupt(uint32_t esp) { return esp; }
 
-    /* 0x00-0xFF(255): Entries in the IDT
-       -> Trap Gate(0x00-0x1F): CPU Exceptions (Faults, Traps),
-       -> Interrupt Gate(0x20-0x2F): IRQ 0–15 (Hardware Interrupts),
-       -> Task Gate(0x30-0xFF): Reserved / Custom Software Interrupts
-     */
-    static struct GateDescriptor idt_entries[256]; // IDT entries
+/* 0x00-0xFF(255): Entries in the IDT
+   -> Trap Gate(0x00-0x1F): CPU Exceptions (Faults, Traps),
+   -> Interrupt Gate(0x20-0x2F): IRQ 0–15 (Hardware Interrupts),
+   -> Task Gate(0x30-0xFF): Reserved / Custom Software Interrupts
+ */
+static struct GateDescriptor idt_entries[256]; // IDT entries
 
-    // set gate descriptor (set the interrupt table entry)
-    void InterruptManager::setGateDescriptor(uint8_t interrupt,
-                                             uint16_t code_seg_selector_offset,
-                                             void (*handler)(),
-                                             uint8_t desc_privilege_level,
-                                             uint8_t desc_type)
-    {
-      // set ISR(Interrupt Service Routine)
-      idt_entries[interrupt].low_offset = ((uint32_t)handler) & 0xFFFF;
-      idt_entries[interrupt].high_offset = (((uint32_t)handler) >> 16) & 0xFFFF;
+// set gate descriptor (set the interrupt table entry)
+void InterruptManager::setGateDescriptor(uint8_t interrupt,
+                                         uint16_t code_seg_selector_offset,
+                                         void (*handler)(),
+                                         uint8_t desc_privilege_level,
+                                         uint8_t desc_type) {
+  // set ISR(Interrupt Service Routine)
+  idt_entries[interrupt].low_offset = ((uint32_t)handler) & 0xFFFF;
+  idt_entries[interrupt].high_offset = (((uint32_t)handler) >> 16) & 0xFFFF;
 
-      // set code segment of the ISR
-      idt_entries[interrupt].code_seg_selector = code_seg_selector_offset;
-      idt_entries[interrupt].zero = 0;
+  // set code segment of the ISR
+  idt_entries[interrupt].code_seg_selector = code_seg_selector_offset;
+  idt_entries[interrupt].zero = 0;
 
-      // set privilege level
-      const uint8_t IDT_DESC_PRESENT = 0x80; // binary: 1000 0000
-      idt_entries[interrupt].type =
-          IDT_DESC_PRESENT | ((desc_privilege_level & 3) << 5) | (desc_type & 0xF);
-    }
+  // set privilege level
+  const uint8_t IDT_DESC_PRESENT = 0x80; // binary: 1000 0000
+  idt_entries[interrupt].type =
+      IDT_DESC_PRESENT | ((desc_privilege_level & 3) << 5) | (desc_type & 0xF);
+}
 
-    // setup interrupt manager
-    InterruptManager::InterruptManager(uint16_t hardware_interrupt_offset,
-                                       uqaabOS::include::GDT *gdt , multitasking::TaskManager* task_manager)
-        : PIC_master_command_port(0x20), PIC_master_data_port(0x21),
-          PIC_slave_command_port(0xA0), PIC_slave_data_port(0xA1)
-    {
+// setup interrupt manager
+InterruptManager::InterruptManager(uint16_t hardware_interrupt_offset,
+                                   uqaabOS::include::GDT *gdt,
+                                   multitasking::TaskManager *task_manager)
+    : PIC_master_command_port(0x20), PIC_master_data_port(0x21),
+      PIC_slave_command_port(0xA0), PIC_slave_data_port(0xA1) {
 
-      this -> task_manager = task_manager;
+  this->task_manager = task_manager;
 
-      this->hardware_interrupt_offset = hardware_interrupt_offset;
-      // ISR code segment
-      uint32_t code_segment = gdt->code_segment_selector();
+  this->hardware_interrupt_offset = hardware_interrupt_offset;
+  // ISR code segment
+  uint32_t code_segment = gdt->code_segment_selector();
 
-      // Gate Type: 32-bit Interrupt Gate: 0xE
-      const uint8_t IDT_INTERRUPT_GATE = 0xE;
-      for (uint8_t i = 255; i > 0; --i)
-      {
-        setGateDescriptor(i, code_segment, &interrupt_ignore, 0,
-                          IDT_INTERRUPT_GATE);
-        handlers[i] = 0;
-      }
-      setGateDescriptor(0, code_segment, &interrupt_ignore, 0, IDT_INTERRUPT_GATE);
-      handlers[0] = 0;
+  // Gate Type: 32-bit Interrupt Gate: 0xE
+  const uint8_t IDT_INTERRUPT_GATE = 0xE;
+  for (uint8_t i = 255; i > 0; --i) {
+    setGateDescriptor(i, code_segment, &interrupt_ignore, 0,
+                      IDT_INTERRUPT_GATE);
+    handlers[i] = 0;
+  }
+  setGateDescriptor(0, code_segment, &interrupt_ignore, 0, IDT_INTERRUPT_GATE);
+  handlers[0] = 0;
 
-      // hardware interrupts, Interrupt Gate
-      setGateDescriptor(hardware_interrupt_offset + 0x00, code_segment, &IRQ0x00, 0,
-                        IDT_INTERRUPT_GATE);
-      setGateDescriptor(hardware_interrupt_offset + 0x01, code_segment, &IRQ0x01, 0,
-                        IDT_INTERRUPT_GATE);
-      setGateDescriptor(hardware_interrupt_offset + 0x02, code_segment, &IRQ0x02, 0,
-                        IDT_INTERRUPT_GATE);
-      setGateDescriptor(hardware_interrupt_offset + 0x03, code_segment, &IRQ0x03, 0,
-                        IDT_INTERRUPT_GATE);
-      setGateDescriptor(hardware_interrupt_offset + 0x04, code_segment, &IRQ0x04, 0,
-                        IDT_INTERRUPT_GATE);
-      setGateDescriptor(hardware_interrupt_offset + 0x05, code_segment, &IRQ0x05, 0,
-                        IDT_INTERRUPT_GATE);
-      setGateDescriptor(hardware_interrupt_offset + 0x06, code_segment, &IRQ0x06, 0,
-                        IDT_INTERRUPT_GATE);
-      setGateDescriptor(hardware_interrupt_offset + 0x07, code_segment, &IRQ0x07, 0,
-                        IDT_INTERRUPT_GATE);
-      setGateDescriptor(hardware_interrupt_offset + 0x08, code_segment, &IRQ0x08, 0,
-                        IDT_INTERRUPT_GATE);
-      setGateDescriptor(hardware_interrupt_offset + 0x09, code_segment, &IRQ0x09, 0,
-                        IDT_INTERRUPT_GATE);
-      setGateDescriptor(hardware_interrupt_offset + 0x0A, code_segment, &IRQ0x0A, 0,
-                        IDT_INTERRUPT_GATE);
-      setGateDescriptor(hardware_interrupt_offset + 0x0B, code_segment, &IRQ0x0B, 0,
-                        IDT_INTERRUPT_GATE);
-      setGateDescriptor(hardware_interrupt_offset + 0x0C, code_segment, &IRQ0x0C, 0,
-                        IDT_INTERRUPT_GATE);
-      setGateDescriptor(hardware_interrupt_offset + 0x0D, code_segment, &IRQ0x0D, 0,
-                        IDT_INTERRUPT_GATE);
-      setGateDescriptor(hardware_interrupt_offset + 0x0E, code_segment, &IRQ0x0E, 0,
-                        IDT_INTERRUPT_GATE);
-      setGateDescriptor(hardware_interrupt_offset + 0x0F, code_segment, &IRQ0x0F, 0,
-                        IDT_INTERRUPT_GATE);
+  // hardware interrupts, Interrupt Gate
+  setGateDescriptor(hardware_interrupt_offset + 0x00, code_segment, &IRQ0x00, 0,
+                    IDT_INTERRUPT_GATE);
+  setGateDescriptor(hardware_interrupt_offset + 0x01, code_segment, &IRQ0x01, 0,
+                    IDT_INTERRUPT_GATE);
+  setGateDescriptor(hardware_interrupt_offset + 0x02, code_segment, &IRQ0x02, 0,
+                    IDT_INTERRUPT_GATE);
+  setGateDescriptor(hardware_interrupt_offset + 0x03, code_segment, &IRQ0x03, 0,
+                    IDT_INTERRUPT_GATE);
+  setGateDescriptor(hardware_interrupt_offset + 0x04, code_segment, &IRQ0x04, 0,
+                    IDT_INTERRUPT_GATE);
+  setGateDescriptor(hardware_interrupt_offset + 0x05, code_segment, &IRQ0x05, 0,
+                    IDT_INTERRUPT_GATE);
+  setGateDescriptor(hardware_interrupt_offset + 0x06, code_segment, &IRQ0x06, 0,
+                    IDT_INTERRUPT_GATE);
+  setGateDescriptor(hardware_interrupt_offset + 0x07, code_segment, &IRQ0x07, 0,
+                    IDT_INTERRUPT_GATE);
+  setGateDescriptor(hardware_interrupt_offset + 0x08, code_segment, &IRQ0x08, 0,
+                    IDT_INTERRUPT_GATE);
+  setGateDescriptor(hardware_interrupt_offset + 0x09, code_segment, &IRQ0x09, 0,
+                    IDT_INTERRUPT_GATE);
+  setGateDescriptor(hardware_interrupt_offset + 0x0A, code_segment, &IRQ0x0A, 0,
+                    IDT_INTERRUPT_GATE);
+  setGateDescriptor(hardware_interrupt_offset + 0x0B, code_segment, &IRQ0x0B, 0,
+                    IDT_INTERRUPT_GATE);
+  setGateDescriptor(hardware_interrupt_offset + 0x0C, code_segment, &IRQ0x0C, 0,
+                    IDT_INTERRUPT_GATE);
+  setGateDescriptor(hardware_interrupt_offset + 0x0D, code_segment, &IRQ0x0D, 0,
+                    IDT_INTERRUPT_GATE);
+  setGateDescriptor(hardware_interrupt_offset + 0x0E, code_segment, &IRQ0x0E, 0,
+                    IDT_INTERRUPT_GATE);
+  setGateDescriptor(hardware_interrupt_offset + 0x0F, code_segment, &IRQ0x0F, 0,
+                    IDT_INTERRUPT_GATE);
 
-      // handle exceptions(Trap Gate)
-      const uint8_t IDT_TRAP_GATE = 0xF;
-      setGateDescriptor(0x00, code_segment, &handle_exception0x00, 0,
-                        IDT_TRAP_GATE);
-      setGateDescriptor(0x01, code_segment, &handle_exception0x01, 0,
-                        IDT_TRAP_GATE);
-      setGateDescriptor(0x02, code_segment, &handle_exception0x02, 0,
-                        IDT_TRAP_GATE);
-      setGateDescriptor(0x03, code_segment, &handle_exception0x03, 0,
-                        IDT_TRAP_GATE);
-      setGateDescriptor(0x04, code_segment, &handle_exception0x04, 0,
-                        IDT_TRAP_GATE);
-      setGateDescriptor(0x05, code_segment, &handle_exception0x05, 0,
-                        IDT_TRAP_GATE);
-      setGateDescriptor(0x06, code_segment, &handle_exception0x06, 0,
-                        IDT_TRAP_GATE);
-      setGateDescriptor(0x07, code_segment, &handle_exception0x07, 0,
-                        IDT_TRAP_GATE);
-      setGateDescriptor(0x08, code_segment, &handle_exception0x08, 0,
-                        IDT_TRAP_GATE);
-      setGateDescriptor(0x09, code_segment, &handle_exception0x09, 0,
-                        IDT_TRAP_GATE);
-      setGateDescriptor(0x0A, code_segment, &handle_exception0x0A, 0,
-                        IDT_TRAP_GATE);
-      setGateDescriptor(0x0B, code_segment, &handle_exception0x0B, 0,
-                        IDT_TRAP_GATE);
-      setGateDescriptor(0x0C, code_segment, &handle_exception0x0C, 0,
-                        IDT_TRAP_GATE);
-      setGateDescriptor(0x0D, code_segment, &handle_exception0x0D, 0,
-                        IDT_TRAP_GATE);
-      setGateDescriptor(0x0E, code_segment, &handle_exception0x0E, 0,
-                        IDT_TRAP_GATE);
-      setGateDescriptor(0x0F, code_segment, &handle_exception0x0F, 0,
-                        IDT_TRAP_GATE);
-      setGateDescriptor(0x10, code_segment, &handle_exception0x10, 0,
-                        IDT_TRAP_GATE);
-      setGateDescriptor(0x11, code_segment, &handle_exception0x11, 0,
-                        IDT_TRAP_GATE);
-      setGateDescriptor(0x12, code_segment, &handle_exception0x12, 0,
-                        IDT_TRAP_GATE);
-      setGateDescriptor(0x13, code_segment, &handle_exception0x13, 0,
-                        IDT_TRAP_GATE);
+  // handle exceptions(Trap Gate)
+  const uint8_t IDT_TRAP_GATE = 0xF;
+  setGateDescriptor(0x00, code_segment, &handle_exception0x00, 0,
+                    IDT_TRAP_GATE);
+  setGateDescriptor(0x01, code_segment, &handle_exception0x01, 0,
+                    IDT_TRAP_GATE);
+  setGateDescriptor(0x02, code_segment, &handle_exception0x02, 0,
+                    IDT_TRAP_GATE);
+  setGateDescriptor(0x03, code_segment, &handle_exception0x03, 0,
+                    IDT_TRAP_GATE);
+  setGateDescriptor(0x04, code_segment, &handle_exception0x04, 0,
+                    IDT_TRAP_GATE);
+  setGateDescriptor(0x05, code_segment, &handle_exception0x05, 0,
+                    IDT_TRAP_GATE);
+  setGateDescriptor(0x06, code_segment, &handle_exception0x06, 0,
+                    IDT_TRAP_GATE);
+  setGateDescriptor(0x07, code_segment, &handle_exception0x07, 0,
+                    IDT_TRAP_GATE);
+  setGateDescriptor(0x08, code_segment, &handle_exception0x08, 0,
+                    IDT_TRAP_GATE);
+  setGateDescriptor(0x09, code_segment, &handle_exception0x09, 0,
+                    IDT_TRAP_GATE);
+  setGateDescriptor(0x0A, code_segment, &handle_exception0x0A, 0,
+                    IDT_TRAP_GATE);
+  setGateDescriptor(0x0B, code_segment, &handle_exception0x0B, 0,
+                    IDT_TRAP_GATE);
+  setGateDescriptor(0x0C, code_segment, &handle_exception0x0C, 0,
+                    IDT_TRAP_GATE);
+  setGateDescriptor(0x0D, code_segment, &handle_exception0x0D, 0,
+                    IDT_TRAP_GATE);
+  setGateDescriptor(0x0E, code_segment, &handle_exception0x0E, 0,
+                    IDT_TRAP_GATE);
+  setGateDescriptor(0x0F, code_segment, &handle_exception0x0F, 0,
+                    IDT_TRAP_GATE);
+  setGateDescriptor(0x10, code_segment, &handle_exception0x10, 0,
+                    IDT_TRAP_GATE);
+  setGateDescriptor(0x11, code_segment, &handle_exception0x11, 0,
+                    IDT_TRAP_GATE);
+  setGateDescriptor(0x12, code_segment, &handle_exception0x12, 0,
+                    IDT_TRAP_GATE);
+  setGateDescriptor(0x13, code_segment, &handle_exception0x13, 0,
+                    IDT_TRAP_GATE);
 
-      // Initialize PIC
-      PIC_master_command_port.write(0x11);
-      PIC_slave_command_port.write(0x11);
-      // Remap the Interrupt Numbers
-      PIC_master_data_port.write(hardware_interrupt_offset);
-      PIC_slave_data_port.write(hardware_interrupt_offset + 8);
-      // Setup PIC Master-Slave Connection
-      PIC_master_data_port.write(0x04);
-      PIC_slave_data_port.write(0x02);
-      // Set PIC Mode
-      PIC_master_data_port.write(0x01);
-      PIC_slave_data_port.write(0x01);
-      // Clear Data Registers
-      PIC_master_data_port.write(0x00);
-      PIC_slave_data_port.write(0x00);
+  // Initialize PIC
+  PIC_master_command_port.write(0x11);
+  PIC_slave_command_port.write(0x11);
+  // Remap the Interrupt Numbers
+  PIC_master_data_port.write(hardware_interrupt_offset);
+  PIC_slave_data_port.write(hardware_interrupt_offset + 8);
+  // Setup PIC Master-Slave Connection
+  PIC_master_data_port.write(0x04);
+  PIC_slave_data_port.write(0x02);
+  // Set PIC Mode
+  PIC_master_data_port.write(0x01);
+  PIC_slave_data_port.write(0x01);
+  // Clear Data Registers
+  PIC_master_data_port.write(0x00);
+  PIC_slave_data_port.write(0x00);
 
-      IDTPointer idt_pointer;
-      idt_pointer.size = 256 * sizeof(GateDescriptor) - 1;
-      idt_pointer.base = (uint32_t)idt_entries;
-      asm volatile("lidt %0" : : "m"(idt_pointer));
-    }
+  IDTPointer idt_pointer;
+  idt_pointer.size = 256 * sizeof(GateDescriptor) - 1;
+  idt_pointer.base = (uint32_t)idt_entries;
+  asm volatile("lidt %0" : : "m"(idt_pointer));
+}
 
-    uint16_t InterruptManager::hardwareInterruptOffset()
-    {
-      return hardware_interrupt_offset;
-    };
+uint16_t InterruptManager::hardwareInterruptOffset() {
+  return hardware_interrupt_offset;
+};
 
-    void InterruptManager::activate()
-    {
+void InterruptManager::activate() {
 
-      if (ActiveInterrruptManager != 0)
-      {
-        ActiveInterrruptManager->deactivate();
-      }
+  if (ActiveInterrruptManager != 0) {
+    ActiveInterrruptManager->deactivate();
+  }
 
-      ActiveInterrruptManager = this;
-      // sti (Set Interrupt Flag in EFLAGS), tells cpu to start accepting interrupts
-      asm("sti");
-    }
+  ActiveInterrruptManager = this;
+  // sti (Set Interrupt Flag in EFLAGS), tells cpu to start accepting interrupts
+  asm("sti");
+}
 
-    void InterruptManager::deactivate()
-    {
-      // cli (Clear Interrupt Flag in EFLAGS), tells cpu to stop accepting
-      // interrupts
-      if (ActiveInterrruptManager == this)
-      {
-        ActiveInterrruptManager = 0;
-        asm("cli");
-      }
-    }
+void InterruptManager::deactivate() {
+  // cli (Clear Interrupt Flag in EFLAGS), tells cpu to stop accepting
+  // interrupts
+  if (ActiveInterrruptManager == this) {
+    ActiveInterrruptManager = 0;
+    asm("cli");
+  }
+}
 
 // Generic ISR handler
 extern "C" uint32_t handle_interrupt(uint8_t interrupt_number, uint32_t esp) {
   if (uqaabOS::interrupts::InterruptManager::ActiveInterrruptManager != 0) {
-    uqaabOS::interrupts::InterruptManager::ActiveInterrruptManager
+    return uqaabOS::interrupts::InterruptManager::ActiveInterrruptManager
         ->do_handle_interrupt(interrupt_number, esp);
   }
 
-      return esp;
-    }
+  return esp;
+}
 
 // Exception messages
 const char *exception_messages[] = {"Divide By Zero Exception\n",
@@ -252,22 +240,20 @@ uint32_t InterruptManager::do_handle_interrupt(uint8_t interrupt_number,
     }
   }
 
-  if(interrupt_number == hardware_interrupt_offset){
-    esp = (uint32_t)(task_manager -> schedule((multitasking::CPUState*)esp));
+  if (interrupt_number == hardware_interrupt_offset) {
+    esp = (uint32_t)(task_manager->schedule((multitasking::CPUState *)esp));
   }
 
-      if (hardware_interrupt_offset <= interrupt_number &&
-          interrupt_number < hardware_interrupt_offset + 16)
-      {
+  if (hardware_interrupt_offset <= interrupt_number &&
+      interrupt_number < hardware_interrupt_offset + 16) {
 
-        PIC_master_command_port.write(0x20);
-        if (hardware_interrupt_offset + 8 <= interrupt_number)
-        {
-          PIC_slave_command_port.write(0x20);
-        }
-      }
-
-      return esp;
+    PIC_master_command_port.write(0x20);
+    if (hardware_interrupt_offset + 8 <= interrupt_number) {
+      PIC_slave_command_port.write(0x20);
     }
-  } // namespace interrupts
+  }
+
+  return esp;
+}
+} // namespace interrupts
 } // namespace uqaabOS

--- a/src/core/interrupts/interruptstub.asm
+++ b/src/core/interrupts/interruptstub.asm
@@ -14,6 +14,7 @@ global handle_exception%1                   ; Make the handler visible to linker
 handle_exception%1:
     push dword [esp]                       ; Save the CPU-pushed error code
     mov dword [interrupt_number], %1        ; Store the exception number in global variable
+    push $0
     jmp int_bottom                         ; Jump to common handler code
 %endmacro
 
@@ -78,24 +79,43 @@ HandleInterruptRequest 0x31      ; Custom IRQ handler
 
 ; Common interrupt handling code
 int_bottom:
-    pusha                               ; Push all general-purpose registers
-    push ds                             ; Push segment registers
+    ;pusha                               ; Push all general-purpose registers
+    ;push ds                             ; Push segment registers
 
 
-    push es
-    push fs
-    push gs
+    ;push es
+    ;push fs
+    ;push gs
+
+    push ebp
+    push edi
+    push esi
+
+    push edx
+    push ecx
+    push ebx
+    push eax
+
     push esp                            ; Push stack pointer as parameter
     push dword [interrupt_number]        ; Push interrupt number as parameter
     call handle_interrupt               ; Call C handler function
-    add esp, 8                          ; Clean up the two parameters we pushed
+    ;add esp, 8                          ; Clean up the two parameters we pushed
     mov esp, eax                        ; Update stack pointer from return value
     
-    pop gs                              ; Restore segment registers
-    pop fs
-    pop es
-    pop ds
-    popa                                ; Restore all general-purpose registers
+    ;pop gs                              ; Restore segment registers
+    ;pop fs
+    ;pop es
+    ;pop ds
+    ;popa                                ; Restore all general-purpose registers
+
+    pop eax
+    pop ebx
+    pop ecx
+    pop edx
+
+    pop esi
+    pop edi
+    pop ebp
     
     ; Check if this exception pushed an error code
     cmp dword [interrupt_number], 0x08  ; Check Double Fault

--- a/src/include/interrupts.h
+++ b/src/include/interrupts.h
@@ -110,6 +110,7 @@ public:
   static InterruptManager *ActiveInterrruptManager;
   InterruptHandler *handlers[256];
   multitasking::TaskManager* task_manager;
+  
   friend class InterruptHandler;
 
 

--- a/src/include/interrupts.h
+++ b/src/include/interrupts.h
@@ -6,6 +6,7 @@
 #include "gdt.h"
 #include "libc/stdio.h"
 #include "port.h"
+#include "multitasking/multitasking.h"
 
 namespace uqaabOS {
 namespace interrupts {
@@ -108,7 +109,7 @@ class InterruptManager {
 public:
   static InterruptManager *ActiveInterrruptManager;
   InterruptHandler *handlers[256];
-
+  multitasking::TaskManager* task_manager;
   friend class InterruptHandler;
 
 
@@ -143,7 +144,7 @@ public:
 
 public:
   InterruptManager(uint16_t hardware_interrupt_offset,
-                   uqaabOS::include::GDT *gdt);
+                   uqaabOS::include::GDT *gdt , multitasking::TaskManager* task_manager);
   ~InterruptManager();
 
   uint16_t hardwareInterruptOffset();

--- a/src/include/multitasking/multitasking.h
+++ b/src/include/multitasking/multitasking.h
@@ -40,7 +40,7 @@ namespace uqaabOS
             CPUState* cpu_state;
 
             public:
-            Task(include::GDT* gdt , void entry_point());
+            Task(include::GDT* gdt , void (*entry_point)());
             ~Task();
         };
 

--- a/src/include/multitasking/multitasking.h
+++ b/src/include/multitasking/multitasking.h
@@ -1,0 +1,68 @@
+#ifndef __MULTITASKING_
+#define __MULTITASKING_
+
+#include <stdint.h>
+
+#include "../gdt.h"
+
+namespace uqaabOS
+{
+    namespace multitasking
+    {
+        
+        
+        struct CPUState{
+
+         uint32_t eax;
+         uint32_t ebx;
+         uint32_t ecx;
+         uint32_t edx;
+
+         uint32_t esi;
+         uint32_t edi;
+         uint32_t ebp;
+
+         uint32_t error;
+
+         uint32_t eip;
+         uint32_t cs;
+         uint32_t eflags;
+         uint32_t esp;
+         uint32_t ss;
+
+        } __attribute__((packed));
+
+
+        class Task{
+            friend class TaskManager;
+            private:
+            uint8_t stack[4096];
+            CPUState* cpu_state;
+
+            public:
+            Task(include::GDT* gdt , void entry_point());
+            ~Task();
+        };
+
+        class TaskManager{
+
+            private:
+
+            Task* tasks[256];
+            int num_tasks;
+            int current_task;
+
+            public:
+
+            TaskManager();
+            ~TaskManager();
+            bool add_task(Task* task);
+            CPUState* schedule(CPUState* cpu_state);
+
+        };
+    } // namespace multitasking
+    
+    
+} // namespace uqaabOS
+
+#endif

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -17,7 +17,6 @@
 #error "This code must be compiled with an x86-elf compiler"
 #endif
 
-
 class PrintfKeyboardEventHandler
     : public uqaabOS::driver::KeyboardEventHandler {
 public:
@@ -66,15 +65,14 @@ public:
   }
 };
 
-
-void taskA(){
-  while(true){
+void taskA() {
+  for (int i = 0; i < 50; i++) {
     uqaabOS::libc::printf("A");
   }
 }
 
-void taskB(){
-  while(true){
+void taskB() {
+  while (true) {
     uqaabOS::libc::printf("B");
   }
 }
@@ -91,15 +89,15 @@ extern "C" void kernel_main() {
   uqaabOS::multitasking::TaskManager task_manager;
 
   // Initialize Task
-  uqaabOS::multitasking::Task task1(&gdt , taskA);
-  uqaabOS::multitasking::Task task2(&gdt , taskB);
+  uqaabOS::multitasking::Task task1(&gdt, taskA);
+  uqaabOS::multitasking::Task task2(&gdt, taskB);
 
   // add task in task manager
-  task_manager.add_task(&task1);
+  // task_manager.add_task(&task1);
   task_manager.add_task(&task2);
 
   // Initialize Interrupts
-  uqaabOS::interrupts::InterruptManager interrupts(0x20, &gdt , &task_manager);
+  uqaabOS::interrupts::InterruptManager interrupts(0x20, &gdt, &task_manager);
 
   uqaabOS::driver::DriverManager driver_manager;
 
@@ -112,7 +110,7 @@ extern "C" void kernel_main() {
   driver_manager.add_driver(&keyboard);
 
   uqaabOS::driver::PCIController pci_controller;
-  pci_controller.select_drivers(&driver_manager , &interrupts);
+  pci_controller.select_drivers(&driver_manager, &interrupts);
 
   uqaabOS::driver::VideoGraphicsArray vga;
 
@@ -126,10 +124,10 @@ extern "C" void kernel_main() {
   // should raise a divide by zero exception
   uqaabOS::libc::print_int(10 / 1);
 
-  vga.set_mode(320, 200, 8);
-  for (int32_t y = 0; y < 200; y++)
-    for (int32_t x = 0; x < 320; x++)
-      vga.put_pixel(x, y, 0x00, 0xFF, 0x00);
+  // vga.set_mode(320, 200, 8);
+  // for (int32_t y = 0; y < 200; y++)
+  //   for (int32_t x = 0; x < 320; x++)
+  //     vga.put_pixel(x, y, 0x00, 0xFF, 0x00);
 
   while (1)
     ;

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -66,15 +66,27 @@ public:
 };
 
 void taskA() {
-  for (int i = 0; i < 50; i++) {
+  for (int i = 0; i < 500; i++) {
     uqaabOS::libc::printf("A");
   }
+
+  return;
 }
 
 void taskB() {
-  while (true) {
+  for (int j = 0; j < 500; j++) {
     uqaabOS::libc::printf("B");
   }
+
+  return;
+}
+
+void taskC() {
+  for (int k = 0; k < 500; k++) {
+    uqaabOS::libc::printf("C");
+  }
+
+  return;
 }
 
 // Kernel entry point
@@ -91,44 +103,21 @@ extern "C" void kernel_main() {
   // Initialize Task
   uqaabOS::multitasking::Task task1(&gdt, taskA);
   uqaabOS::multitasking::Task task2(&gdt, taskB);
+  uqaabOS::multitasking::Task task3(&gdt, taskC);
+  // uqaabOS::multitasking::Task task4(&gdt, taskD);
 
-  // add task in task manager
-  // task_manager.add_task(&task1);
+  // Add tasks to task manager
+  task_manager.add_task(&task1);
   task_manager.add_task(&task2);
+  task_manager.add_task(&task3);
+  // task_manager.add_task(&task4);
 
-  // Initialize Interrupts
-  uqaabOS::interrupts::InterruptManager interrupts(0x20, &gdt, &task_manager);
+  // Initialize InterruptManager with TaskManager
+  uqaabOS::interrupts::InterruptManager interrupt_manager(0x20, &gdt,
+                                                          &task_manager);
+  interrupt_manager.activate();
 
-  uqaabOS::driver::DriverManager driver_manager;
-
-  MouseToConsole mouse_event_driver;
-  uqaabOS::driver::MouseDriver mouse(&interrupts, &mouse_event_driver);
-  driver_manager.add_driver(&mouse);
-
-  PrintfKeyboardEventHandler keyboard_event_driver;
-  uqaabOS::driver::KeyboardDriver keyboard(&interrupts, &keyboard_event_driver);
-  driver_manager.add_driver(&keyboard);
-
-  uqaabOS::driver::PCIController pci_controller;
-  pci_controller.select_drivers(&driver_manager, &interrupts);
-
-  uqaabOS::driver::VideoGraphicsArray vga;
-
-  driver_manager.activate_all();
-
-  // driver_manager.add_driver(&keyboard);
-  // driver_manager.add_driver(&mouse);
-
-  interrupts.activate();
-
-  // should raise a divide by zero exception
-  uqaabOS::libc::print_int(10 / 1);
-
-  // vga.set_mode(320, 200, 8);
-  // for (int32_t y = 0; y < 200; y++)
-  //   for (int32_t x = 0; x < 320; x++)
-  //     vga.put_pixel(x, y, 0x00, 0xFF, 0x00);
-
-  while (1)
+  // Start multitasking
+  while (true)
     ;
 }

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -8,7 +8,7 @@
 #include "include/gdt.h"
 #include "include/interrupts.h"
 #include "include/libc/stdio.h"
-
+#include "include/multitasking/multitasking.h"
 
 // Compiler checks
 #if defined(__linux__)
@@ -67,6 +67,18 @@ public:
 };
 
 
+void taskA(){
+  while(true){
+    uqaabOS::libc::printf("A");
+  }
+}
+
+void taskB(){
+  while(true){
+    uqaabOS::libc::printf("B");
+  }
+}
+
 // Kernel entry point
 extern "C" void kernel_main() {
   uqaabOS::libc::printf("Hello, World!\n");
@@ -75,8 +87,19 @@ extern "C" void kernel_main() {
   uqaabOS::include::GDT gdt;
   uqaabOS::libc::printf("Loaded GDT....\n");
 
+  // Initialize TaskManager
+  uqaabOS::multitasking::TaskManager task_manager;
+
+  // Initialize Task
+  uqaabOS::multitasking::Task task1(&gdt , taskA);
+  uqaabOS::multitasking::Task task2(&gdt , taskB);
+
+  // add task in task manager
+  task_manager.add_task(&task1);
+  task_manager.add_task(&task2);
+
   // Initialize Interrupts
-  uqaabOS::interrupts::InterruptManager interrupts(0x20, &gdt);
+  uqaabOS::interrupts::InterruptManager interrupts(0x20, &gdt , &task_manager);
 
   uqaabOS::driver::DriverManager driver_manager;
 

--- a/src/multitasking/multitasking.cpp
+++ b/src/multitasking/multitasking.cpp
@@ -1,0 +1,67 @@
+#include "../include/multitasking/multitasking.h"
+// #include "../include/gdt.h"
+
+#include "../include/gdt.h"
+
+namespace uqaabOS
+{
+    namespace multitasking
+    {
+
+        include::GDT* gdt ;
+        Task::Task(uqaabOS::include::GDT* gdt , void entry_point()){
+            cpu_state = (CPUState*)(stack + 4096 - sizeof(CPUState));
+
+            cpu_state -> eax = 0;
+            cpu_state -> ebx = 0;
+            cpu_state -> ecx = 0;
+            cpu_state -> edx = 0;
+
+            cpu_state -> esi = 0;
+            cpu_state -> edi = 0;
+            cpu_state -> ebp = 0;
+
+            cpu_state -> eip = (uint32_t)entry_point;
+            cpu_state -> cs = gdt -> code_segment_selector();
+
+            cpu_state -> eflags = 0x202;
+        }
+        
+        Task::~Task(){}
+
+        TaskManager::TaskManager(){
+            num_tasks = 0;
+            current_task = -1;
+        }
+
+        TaskManager::~TaskManager(){}
+
+        bool TaskManager::add_task(Task* task){
+
+            if(num_tasks >= 256)
+            return false;
+
+            tasks[num_tasks++] = task;
+
+            return true;
+        }
+
+        CPUState* TaskManager::schedule(CPUState* cpu_state){
+
+            if(num_tasks <= 0){
+                return cpu_state;
+            }
+
+            if(current_task >= 0){
+                tasks[current_task] -> cpu_state = cpu_state;
+            }
+
+            if(++current_task >= num_tasks){
+                current_task %= num_tasks;
+            }
+
+            return tasks[current_task] -> cpu_state;
+        }
+    } // namespace multitasking
+    
+} // namespace uqaabOS

--- a/src/multitasking/multitasking.cpp
+++ b/src/multitasking/multitasking.cpp
@@ -3,65 +3,63 @@
 
 #include "../include/gdt.h"
 
-namespace uqaabOS
-{
-    namespace multitasking
-    {
+namespace uqaabOS {
+namespace multitasking {
 
-        include::GDT* gdt ;
-        Task::Task(uqaabOS::include::GDT* gdt , void (*entry_point)()){
-            cpu_state = (CPUState*)(stack + 4096 - sizeof(CPUState));
+include::GDT *gdt;
+Task::Task(uqaabOS::include::GDT *gdt, void (*entry_point)()) {
+  cpu_state = (CPUState *)(stack + 4096 - sizeof(CPUState));
 
-            cpu_state -> eax = 0;
-            cpu_state -> ebx = 0;
-            cpu_state -> ecx = 0;
-            cpu_state -> edx = 0;
+  cpu_state->eax = 0;
+  cpu_state->ebx = 0;
+  cpu_state->ecx = 0;
+  cpu_state->edx = 0;
 
-            cpu_state -> esi = 0;
-            cpu_state -> edi = 0;
-            cpu_state -> ebp = 0;
+  cpu_state->esi = 0;
+  cpu_state->edi = 0;
+  cpu_state->ebp = 0;
 
-            cpu_state -> eip = (uint32_t)entry_point;
-            cpu_state -> cs = gdt -> code_segment_selector();
+  cpu_state->eip = (uint32_t)entry_point;
+  cpu_state->cs = gdt->code_segment_selector();
 
-            cpu_state -> eflags = 0x202;
-        }
-        
-        Task::~Task(){}
+  cpu_state->eflags = 0x202;
+}
 
-        TaskManager::TaskManager(){
-            num_tasks = 0;
-            current_task = -1;
-        }
+Task::~Task() {}
 
-        TaskManager::~TaskManager(){}
+TaskManager::TaskManager() {
+  num_tasks = 0;
+  current_task = -1;
+}
 
-        bool TaskManager::add_task(Task* task){
+TaskManager::~TaskManager() {}
 
-            if(num_tasks >= 256)
-            return false;
+bool TaskManager::add_task(Task *task) {
 
-            tasks[num_tasks++] = task;
+  if (num_tasks >= 256)
+    return false;
 
-            return true;
-        }
+  tasks[num_tasks++] = task;
 
-        CPUState* TaskManager::schedule(CPUState* cpu_state){
+  return true;
+}
 
-            if(num_tasks <= 0){
-                return cpu_state;
-            }
+CPUState *TaskManager::schedule(CPUState *cpu_state) {
 
-            if(current_task >= 0){
-                tasks[current_task] -> cpu_state = cpu_state;
-            }
+  if (num_tasks <= 0) {
+    return cpu_state;
+  }
 
-            if(++current_task >= num_tasks){
-                current_task %= num_tasks;
-            }
+  if (current_task >= 0) {
+    tasks[current_task]->cpu_state = cpu_state;
+  }
 
-            return tasks[current_task] -> cpu_state;
-        }
-    } // namespace multitasking
-    
+  if (++current_task >= num_tasks) {
+    current_task %= num_tasks;
+  }
+
+  return tasks[current_task]->cpu_state;
+}
+} // namespace multitasking
+
 } // namespace uqaabOS

--- a/src/multitasking/multitasking.cpp
+++ b/src/multitasking/multitasking.cpp
@@ -19,6 +19,8 @@ Task::Task(uqaabOS::include::GDT *gdt, void (*entry_point)()) {
   cpu_state->edi = 0;
   cpu_state->ebp = 0;
 
+  cpu_state->esp = (uint32_t)(stack + 4096 - sizeof(CPUState));
+
   cpu_state->eip = (uint32_t)entry_point;
   cpu_state->cs = gdt->code_segment_selector();
 

--- a/src/multitasking/multitasking.cpp
+++ b/src/multitasking/multitasking.cpp
@@ -9,7 +9,7 @@ namespace uqaabOS
     {
 
         include::GDT* gdt ;
-        Task::Task(uqaabOS::include::GDT* gdt , void entry_point()){
+        Task::Task(uqaabOS::include::GDT* gdt , void (*entry_point)()){
             cpu_state = (CPUState*)(stack + 4096 - sizeof(CPUState));
 
             cpu_state -> eax = 0;


### PR DESCRIPTION
 There is still bug, not proper handling of `context switching`, while switching tasks there is corruption of stack the issue arises may be improper context switching. Three task handled correctly and `context switching` is happening but still if we try to do more task there is `Invalid Opcode(Exception number: 0x06)` is coming trying find root cause of this issue but maybe arising due to invalid `eip` register value because of corruption of stack.

### Trace of bug in `GDB`
```
Breakpoint 4, uqaabOS::multitasking::TaskManager::schedule (this=0x209bc8, cpu_state=0x209bb8) at src/multitasking/multitasking.cpp:49
49	  if (num_tasks <= 0) {
(gdb) bt
#0  uqaabOS::multitasking::TaskManager::schedule (this=0x209bc8, cpu_state=0x209bb8) at src/multitasking/multitasking.cpp:49
#1  0x00201012 in uqaabOS::interrupts::InterruptManager::do_handle_interrupt (this=0x206794, interrupt_number=32 ' ', esp=2137016) at src/core/interrupts/interrupts.cpp:244
#2  0x00200f4c in uqaabOS::interrupts::handle_interrupt (interrupt_number=32 ' ', esp=2137016) at src/core/interrupts/interrupts.cpp:201
#3  0x002012ec in int_bottom ()
#4  0x00207bc0 in stack_bottom ()
#5  0x00000000 in ?? ()
Backtrace stopped: previous frame inner to this frame (corrupt stack?)
(gdb) n
53	  if (current_task >= 0) {
(gdb) n
54	    tasks[current_task]->cpu_state = cpu_state;
(gdb) p (uqaabOS::multitasking::CPUState*)cpu_state
$9 = (uqaabOS::multitasking::CPUState *) 0x209bb8
(gdb) p (uqaabOS::multitasking::CPUState*) 0x209bb8
$10 = (uqaabOS::multitasking::CPUState *) 0x209bb8
(gdb) p *(uqaabOS::multitasking::CPUState*) 0x209bb8
$11 = {eax = 0, ebx = 0, ecx = 0, edx = 0, esi = 2132932, edi = 2136976, ebp = 2128832, error = 0, eip = 1408262425, cs = 16, eflags = 518, esp = 0, ss = 0}
(gdb) p current_task
$12 = 0
(gdb) n
57	  if (++current_task >= num_tasks) {
(gdb) n
61	  return tasks[current_task]->cpu_state;
(gdb) bt
#0  uqaabOS::multitasking::TaskManager::schedule (this=0x209bc8, cpu_state=0x209bb8) at src/multitasking/multitasking.cpp:61
#1  0x00201012 in uqaabOS::interrupts::InterruptManager::do_handle_interrupt (this=0x206794, interrupt_number=32 ' ', esp=2137016) at src/core/interrupts/interrupts.cpp:244
#2  0x00200f4c in uqaabOS::interrupts::handle_interrupt (interrupt_number=32 ' ', esp=2137016) at src/core/interrupts/interrupts.cpp:201
#3  0x002012ec in int_bottom ()
#4  0x00207bc0 in stack_bottom ()
#5  0x00000000 in ?? ()
Backtrace stopped: previous frame inner to this frame (corrupt stack?)
(gdb) n
62	}
(gdb) b taskB
Breakpoint 7 at 0x200042: file src/kernel.cpp, line 75.
(gdb) n
uqaabOS::interrupts::InterruptManager::do_handle_interrupt (this=0x206794, interrupt_number=32 ' ', esp=0) at src/core/interrupts/interrupts.cpp:247
247	  if (hardware_interrupt_offset <= interrupt_number &&
(gdb) bt
#0  uqaabOS::interrupts::InterruptManager::do_handle_interrupt (this=0x206794, interrupt_number=32 ' ', esp=0) at src/core/interrupts/interrupts.cpp:247
#1  0x00200f4c in uqaabOS::interrupts::handle_interrupt (interrupt_number=32 ' ', esp=2137016) at src/core/interrupts/interrupts.cpp:201
#2  0x002012ec in int_bottom ()
#3  0x00207bc0 in stack_bottom ()
#4  0x00000000 in ?? ()
Backtrace stopped: previous frame inner to this frame (corrupt stack?)
(gdb) n
248	      interrupt_number < hardware_interrupt_offset + 16) {
(gdb) n
247	  if (hardware_interrupt_offset <= interrupt_number &&
(gdb) n
250	    PIC_master_command_port.write(0x20);
(gdb) n
251	    if (hardware_interrupt_offset + 8 <= interrupt_number) {
(gdb) n
256	  return esp;
(gdb) p esp
$13 = 0
(gdb) n
257	}
(gdb) n
uqaabOS::interrupts::handle_interrupt (interrupt_number=32 ' ', esp=2137016) at src/core/interrupts/interrupts.cpp:205
205	}
(gdb) n
0x002012ec in int_bottom ()
(gdb) n
Single stepping until exit from function int_bottom,
which has no line number information.
0x00201147 in handle_exception0x0 ()
(gdb) n
Single stepping until exit from function handle_exception0x0B,
which has no line number information.
0x002012d9 in int_bottom ()
(gdb) n
Single stepping until exit from function int_bottom,
which has no line number information.
uqaabOS::interrupts::handle_interrupt (interrupt_number=216 '\330', esp=14703594) at src/core/interrupts/interrupts.cpp:198
198	extern "C" uint32_t handle_interrupt(uint8_t interrupt_number, uint32_t esp) {
(gdb) n

Breakpoint 2.2, uqaabOS::interrupts::handle_interrupt (interrupt_number=216 '\330', esp=14703594) at src/core/interrupts/interrupts.cpp:199
199	  if (uqaabOS::interrupts::InterruptManager::ActiveInterrruptManager != 0) {
(gdb) n
201	        ->do_handle_interrupt(interrupt_number, esp);
(gdb) n
uqaabOS::interrupts::InterruptManager::do_handle_interrupt (this=0x8966ef66, interrupt_number=200 '\310', esp=1996355715) at src/core/interrupts/interrupts.cpp:231
231	                                               uint32_t esp) {
(gdb) n

Breakpoint 3, uqaabOS::interrupts::InterruptManager::do_handle_interrupt (this=0x8966ef66, interrupt_number=200 '\310', esp=1996355715)
    at src/core/interrupts/interrupts.cpp:232
232	  if (handlers[interrupt_number] != 0) {
(gdb) n
234	  } else if (interrupt_number != hardware_interrupt_offset) {
(gdb) n
235	    if (interrupt_number <
(gdb) n
239	      libc::printf("UNHANDLED INTERRUPT 0x%02X\n", interrupt_number);
(gdb) n
uqaabOS::libc::printf (format=0x1278c084 <error: Cannot access memory at address 0x1278c084>) at src/libc/stdio.cpp:57
57	void printf(const char *format, ...) {
(gdb) bt
#0  uqaabOS::libc::printf (format=0x1278c084 <error: Cannot access memory at address 0x1278c084>) at src/libc/stdio.cpp:57
#1  0xec00000c in ?? ()
#2  0x1278c084 in ?? ()
#3  0x08c18366 in ?? ()
#4  0x0cf8be66 in ?? ()
#5  0xbf660000 in ?? ()
#6  0x00000cfc in ?? ()
#7  0xf2896680 in ?? ()
#8  0x8966ef66 in ?? ()
#9  0x4866edfa in ?? ()
#10 0x76fdf883 in ?? ()
#11 0x07c1f61c in ?? ()
Backtrace stopped: previous frame inner to this frame (corrupt stack?)
```